### PR TITLE
Extends contextTypes of the passed component instead of overriding it

### DIFF
--- a/src/local.js
+++ b/src/local.js
@@ -55,12 +55,13 @@ export default (Config) => (Component) => {
             );
         }
     }
-    UI.contextTypes = {
+
+    UI.contextTypes = Object.assign({}, Component.contextTypes, {
         store: React.PropTypes.shape({
             subscribe: React.PropTypes.func.isRequired,
             dispatch: React.PropTypes.func.isRequired,
             getState: React.PropTypes.func.isRequired
         })
-    };
+    });
     return UI;
 };


### PR DESCRIPTION
This is to allow passing of `contextType` directly, like so:

```typescript
@local({
  key: (props, context) => context.myCustomContext,
  mapDispatchToProps: (dispatch) => bindActionCreators(myActions, dispatch)
})
class MyComponent extends React.Component<Props, void> {

  static contextTypes = {
    myCustomContext: React.PropTypes.string
  }

  render() {
    // ...
  }
}
```

Otherwise, with the current implementation, I have to do:


```typescript

class MyComponent extends React.Component<Props, void> {

  render() {
    // ...
  }
}

let WrappedComp = local({
  key: (props, context) => context.myCustomContext,
  mapDispatchToProps: (dispatch) => bindActionCreators(myActions, dispatch)
})(MyComponent)

WrappedComp.contextTypes = {
  myCustomContext: React.PropTypes.string
}

export default WrappedComp

```