### PR TITLE
Support redux-immutable

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "eslint-plugin-import": "^1.14.0",
     "eslint-plugin-jsx-a11y": "^2.2.1",
     "eslint-plugin-react": "^6.2.0",
+    "immutable": "^3.8.1",
     "jsdom": "^9.4.2",
     "nyc": "^8.1.0",
     "react": "^15.3.1",
@@ -85,6 +86,7 @@
     "react-dom": "^15.3.1",
     "react-redux": "^4.4.5",
     "redux": "^3.5.2",
+    "redux-immutable": "^3.1.0",
     "redux-saga": "^0.12.0",
     "rimraf": "^2.5.4",
     "sinon": "^1.17.6"

--- a/src/local.js
+++ b/src/local.js
@@ -28,7 +28,8 @@ export default (Config) => (Component) => {
       this.unsubscribe = null;
     }
     componentWillMount() {
-      const existingState = this.context.store.getState().local[this.compKey];
+      const state = this.context.store.getState();
+      const existingState = (typeof state.get === 'function' ? state.get('local') : state.local)[this.compKey];
       const storeResult = createStore(
                 Config.createStore, this.props,
                 this.compKey, existingState, this.context);

--- a/tests/helpers/configureStore.js
+++ b/tests/helpers/configureStore.js
@@ -1,8 +1,13 @@
 import localReducer from '../../src/localReducer.js';
 import { createStore, combineReducers } from 'redux';
-export function configureStore() {
+import { combineReducers as immutableCombineReducers } from 'redux-immutable';
+import Immutable from 'immutable';
+
+export function configureStore(asImmutable = false) {
+  const initalState = asImmutable ? Immutable.Map({}) : {};
+  const combiner    = asImmutable ? immutableCombineReducers : combineReducers;
   const store = createStore(
-            combineReducers({
+            combiner({
               local: localReducer,
               isVisible: (state = true, action) => {
                 switch (action.type) {
@@ -20,7 +25,8 @@ export function configureStore() {
                     return state;
                 }
               },
-            })
+            }),
+            initalState
         );
   return store;
 }

--- a/tests/localSpec.js
+++ b/tests/localSpec.js
@@ -85,6 +85,30 @@ test('Should return the correct initial state for the component', t => {
     return new Promise((resolve) => setTimeout(() => resolve(), 10));
 });
 
+test('Should return the correct initial state for the component when redux store is Immutable.Map', t => {
+    const CompToRender = local({
+        key: 'myDumbComp',
+        filterGlobalActions: (action) => {
+            return false;
+        },
+        createStore: (props) => {
+            return createStore(rootReducer, { filter: true, sort: props.sortOrder })
+        },
+        mapDispatchToProps:(dispatch) => ({
+            onFilter: (filter) => dispatch({ type: 'SET_FILTER', payload: filter  }),
+            onSort: (sort) => dispatch({ type: 'SET_SORT', payload: sort }),
+        })
+    })(DummyComp);
+    const wrapper = mount(<Provider store={configureStore(true)}><CompToRender sortOrder='desc' /></Provider>);
+    const filterVal = wrapper.find('DummyComp').props().filter;
+    const sortVal = wrapper.find('DummyComp').props().sort;
+    t.deepEqual(filterVal, true);
+    t.deepEqual(sortVal, 'desc');
+    wrapper.unmount();
+    console.log('FUCKER')
+    return new Promise((resolve) => setTimeout(() => resolve(), 10));
+});
+
 test(`Should dispatch local actions that update component state. The local actions
       should also hit the global app reducers`, t => {
     const Store = configureStore();
@@ -437,7 +461,7 @@ test(`Should be able to control whether the component state is persisted or not
         t.deepEqual(Store.getState().local, {'b': {filter: true, sort: 'asc'}});
         Store.dispatch(destroyAllComponentsState());
         resolve();
-    }, 10)); 
+    }, 10));
 });
 
 test(`Should pass the component context as last argument to callback style configs`, t => {
@@ -745,8 +769,8 @@ are local HOCS nested and one of the child local unmounts as the result of a par
                 existingState || { isOpen: true }
             );
         },
-        mapDispatchToProps: (dispatch) => ({ 
-            onClose: () => dispatch({ type: 'CLOSE' }) 
+        mapDispatchToProps: (dispatch) => ({
+            onClose: () => dispatch({ type: 'CLOSE' })
         })
     });
     const SFC = (props) => (


### PR DESCRIPTION
When using [redux-immutable](https://github.com/gajus/redux-immutable) the state is an instance of `Immutable.Iterable` so add support by checking for existence of `get` function on the state.